### PR TITLE
support passing optional request arguments.

### DIFF
--- a/djinn/__init__.py
+++ b/djinn/__init__.py
@@ -14,4 +14,4 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-__version__ = '1.1.5'
+__version__ = '1.1.6'

--- a/djinn/options.py
+++ b/djinn/options.py
@@ -30,7 +30,7 @@ def parse_config_file(filename):
     from a configuration file.
     """
     config = {}
-    execfile(filename, None, config)
+    execfile(filename, {}, config)
     for name in config:
         if name in options._options:
             options._options[name].set(config[name])

--- a/djinn/validators.py
+++ b/djinn/validators.py
@@ -21,7 +21,6 @@ from djinn import errors
 
 
 class Validator(object):
-
     """Basic Validator class"""
     _error_message = "%s is an invalid param"
 
@@ -36,10 +35,13 @@ class Validator(object):
             def __validate(handler, *args, **kwargs):
                 # validate handler.arguments
                 self.handler = handler
+                if self.get_argument(self.param) is None and self.default is None:
+                    return func(handler, *args, **kwargs)
                 self.validate()
                 return func(handler, *args, **kwargs)
 
             return __validate
+
         self._validate = _validate
 
     def __call__(self, *args, **kwargs):
@@ -183,14 +185,13 @@ class Email(Regex):
 
     def __init__(self, param, message=None, code=400):
         # borrow email re pattern from django
-        regex =  r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z]+)*" \
-            r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-011\013\014\016-\177])*"' \
-            r")@(?:[A-Z0-9]+(?:-*[A-Z0-9]+)*\.)+[A-Z]{2,6}$"
+        regex = r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z]+)*" \
+                r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-011\013\014\016-\177])*"' \
+                r")@(?:[A-Z0-9]+(?:-*[A-Z0-9]+)*\.)+[A-Z]{2,6}$"
         flags = re.IGNORECASE
         default = ""
 
-        super(Email, self).__init__(param, regex,
-                                    flags, default, message, code)
+        super(Email, self).__init__(param, regex, flags, default, message, code)
 
 
 required = Required

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     pass
 
-version = "1.1.5"
+version = "1.1.6"
 
 distutils.core.setup(
     name="djinn",


### PR DESCRIPTION
fix `execfile`  bug.
validators add optional request arguments. if set default argument to None, and this argument not in request arguments, the this argument`s validator will pass.